### PR TITLE
Rollback to Newtonsoft.Json 12.0.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,5 @@ updates:
   - 'dependencies'
   reviewers:
   - 'microsoft/psrule-rules-github'
+  ignore:
+  - dependency-name: Newtonsoft.Json

--- a/src/PSRule.Rules.GitHub/PSRule.Rules.GitHub.csproj
+++ b/src/PSRule.Rules.GitHub/PSRule.Rules.GitHub.csproj
@@ -26,11 +26,11 @@ This project is to be considered a proof-of-concept and not a supported product.
 
   <ItemGroup>
     <PackageReference Include="Octokit" Version="0.50.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.0" PrivateAssets="All" />
     <PackageReference Include="YamlDotNet" Version="9.1.4" />
   </ItemGroup>


### PR DESCRIPTION
## PR Summary

- Rollback Newtonsoft.Json to v12.0.3.
- Update to use new analysers.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
