### PR TITLE
Pre-release v0.1.0-B2104014

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.1.0-B2104014 (pre-release)
+
 What's changed since pre-release v0.1.0-B2103003:
 
 - General improvements:
@@ -10,7 +12,7 @@ What's changed since pre-release v0.1.0-B2103003:
   - Added resource API versions. [#66](https://github.com/microsoft/PSRule.Rules.GitHub/issues/66)
 - Engineering:
   - Bump YamlDotNet to 11.1.1. [#61](https://github.com/microsoft/PSRule.Rules.GitHub/pull/61)
-  - Bump PSRule dependency to v1.1.0. [#67](https://github.com/microsoft/PSRule.Rules.GitHub/issues/67)
+  - Bump PSRule dependency to v1.2.0. [#67](https://github.com/microsoft/PSRule.Rules.GitHub/issues/67)
     - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md#v120)
 - Bug fixes:
   - Fixed null community profile. [#65](https://github.com/microsoft/PSRule.Rules.GitHub/issues/65)

--- a/ps-project.yaml
+++ b/ps-project.yaml
@@ -16,7 +16,7 @@ bugs:
   url: https://github.com/Microsoft/PSRule.Rules.GitHub/issues
 
 modules:
-  PSRule: ^1.1.0
+  PSRule: ^1.2.0
 
 tasks:
   clear:


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v0.1.0-B2103003:

- General improvements:
  - Export pull request reviews branch protection data. #63
  - Export additional repository data. #64
  - Added resource API versions. #66
- Engineering:
  - Bump YamlDotNet to 11.1.1. #61
  - Bump PSRule dependency to v1.2.0. #67
    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md#v120)
- Bug fixes:
  - Fixed null community profile. #65

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
