### PR TITLE
Pre-release v0.2.0-B2205009

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.2.0-B2205009 (pre-release)
+
 What's changed since pre-release v0.2.0-B2204030:
 
 - Engineering:


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v0.2.0-B2204030:

- Engineering:
  - Bump PSRule to v2.1.0. #117
  - Bump Pester to v5.3.3. #114

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
