### PR TITLE
Release v0.3.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -30,7 +30,7 @@ Capture any error messages and or verbose messages with `-Verbose`.
 **Module in use and version:**
 
 - Module: PSRule.Rules.GitHub
-- Version: **[e.g. 0.2.0]**
+- Version: **[e.g. 0.3.0]**
 
 Captured output from `$PSVersionTable`:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Unreleased
 
+## v0.3.0
+
+What's changed since v0.2.0:
+
+- Engineering:
+  - Added support for NuGet publishing by @BernieWhite.
+    [#132](https://github.com/microsoft/PSRule.Rules.GitHub/issues/132)
+  - Bump PSRule to v2.2.0.
+    [#123](https://github.com/microsoft/PSRule.Rules.GitHub/pull/123)
+  - Bump Octokit to v1.0.1.
+    [#137](https://github.com/microsoft/PSRule.Rules.GitHub/pull/137)
+  - Update packaging for code signing and SBOM by @BernieWhite.
+    [#131](https://github.com/microsoft/PSRule.Rules.GitHub/issues/131)
+  - Bump xunit to v2.4.2.
+    [#138](https://github.com/microsoft/PSRule.Rules.GitHub/pull/138)
+
+What's changed since pre-release v0.3.0-B0008:
+
+- No additional changes.
+
 ## v0.3.0-B0008 (pre-release)
 
 What's changed since v0.2.0:


### PR DESCRIPTION
## PR Summary

What's changed since v0.2.0:

- Engineering:
  - Added support for NuGet publishing by @BernieWhite.
    [#132](https://github.com/microsoft/PSRule.Rules.GitHub/issues/132)
  - Bump PSRule to v2.2.0.
    [#123](https://github.com/microsoft/PSRule.Rules.GitHub/pull/123)
  - Bump Octokit to v1.0.1.
    [#137](https://github.com/microsoft/PSRule.Rules.GitHub/pull/137)
  - Update packaging for code signing and SBOM by @BernieWhite.
    [#131](https://github.com/microsoft/PSRule.Rules.GitHub/issues/131)
  - Bump xunit to v2.4.2.
    [#138](https://github.com/microsoft/PSRule.Rules.GitHub/pull/138)

What's changed since pre-release v0.3.0-B0008:

- No additional changes.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
