### PR TITLE
Pre-release v0.4.0-B0016

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.4.0-B0016 (pre-release)
+
 What's changed since v0.3.0:
 
 - Engineering:


### PR DESCRIPTION
## PR Summary

What's changed since v0.3.0:

- Engineering:
  - Bump PSRule to v2.7.0.
    [#177](https://github.com/microsoft/PSRule.Rules.GitHub/pull/177)
  - Bump Pester to v5.4.0.
    [#177](https://github.com/microsoft/PSRule.Rules.GitHub/pull/177)
  - Bump Microsoft.NET.Test.Sdk to v17.4.1.
    [#175](https://github.com/microsoft/PSRule.Rules.GitHub/pull/175)
  - Bump Octokit from 1.0.1 to 5.0.0.
    [#181](https://github.com/microsoft/PSRule.Rules.GitHub/pull/181)
  - Bump coverlet.collector to v3.2.0.
    [#165](https://github.com/microsoft/PSRule.Rules.GitHub/pull/165)
  - Bump PSScriptAnalyzer to v1.21.0.
    [#142](https://github.com/microsoft/PSRule.Rules.GitHub/pull/142)
  - Bump Microsoft.CodeAnalysis.NetAnalyzers to v7.0.0.
    [#171](https://github.com/microsoft/PSRule.Rules.GitHub/pull/171)
- Bug fixes:
  - Fixes forbidden repository protection crashes export by @BernieWhite.
    [#184](https://github.com/microsoft/PSRule.Rules.GitHub/issues/184)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
